### PR TITLE
Extend parser to includes related resources from includesMap

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './jsonTypes';
 export * from './jsonApiTypes';
 export * from './utils';
+export * from './typeGuards';

--- a/packages/core/src/typeGuards.ts
+++ b/packages/core/src/typeGuards.ts
@@ -1,0 +1,7 @@
+import { JSONValue, JSONObject } from './jsonTypes';
+
+export const isJSONObject = (value: JSONValue): value is JSONObject =>
+  !Array.isArray(value) && value !== null && typeof value === 'object';
+
+export const isJSONValueArray = (value: JSONValue | JSONValue[] | null): value is JSONValue[] =>
+  value !== null && Array.isArray(value);


### PR DESCRIPTION
**Description**:
Extend parse function with resolve function to nested resources which might appear due to relationships of included resources. 
- Implementation resolves single resource as well as array of resources.
- I decided to go with the simplest solution and match the resources based on the related id rather than using registry to resolve that. I had problem with connecting the parse method with our registry and resolving the attributes, relationships and so on that object. 
- Right now we are automatically include every related resource, i wonder if we wish to have control over that? If yes probably we would need to implement that solution using the registry, or define additional option on the parse function to include those properties if needed.
- The names of the included resources are based on their type, which means that we need to use `keyParseFunc` (if there is a better solution let me know) which requires to define `keyTransform` key in the `options`  of the `Registry`. I've extended our `Resource.parse` mock registry with that key defined. 

I'll appreciate the feedback according to the code & solution i've implemented.

Please let me know if you're seeing any kind of edge case which isn't covered or which might bring us closer to unexpected issues.