### PR TITLE
Different approach for filtering never types

### DIFF
--- a/packages/fresha-redux-orm/src/types.ts
+++ b/packages/fresha-redux-orm/src/types.ts
@@ -236,7 +236,7 @@ export type RefWithFields<MClass extends AnyModel> = {
 /**
  * Maps passed fields map to become a plain JS object representing the database entry.
  */
-export type RefLike<MFieldMap extends ModelFieldMap = ModelFieldMap> = {
+type RefLike<MFieldMap extends ModelFieldMap = ModelFieldMap> = {
   [K in keyof MFieldMap]: ExcludeUndefined<MFieldMap[K]> extends QuerySet
     ? never
     : ExcludeUndefined<MFieldMap[K]> extends AnyModel
@@ -247,7 +247,7 @@ export type RefLike<MFieldMap extends ModelFieldMap = ModelFieldMap> = {
 /**
  * Filters out attributes of never type in passed fields map.
  */
-export type FilterOutNeverTypes<MFieldMap extends ModelFieldMap = ModelFieldMap> = {
+type FilterOutNeverTypes<MFieldMap extends ModelFieldMap = ModelFieldMap> = {
   [K in keyof MFieldMap as ExcludeUndefined<MFieldMap[K]> extends never ? never : K]: MFieldMap[K]
 } 
 


### PR DESCRIPTION
It leaves the ref's id attribute for 1to1 backwards relation key. Filtering out this attr was producing circular type references.

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you propose PR to correct branch: hotfix for `master`, feature for latest active branch `feature/x`.
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.
